### PR TITLE
fix: correct command examples in README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -103,10 +103,10 @@ mst create feature/awesome-feature --tmux --claude
 | 目的                                    | コマンド例                                                                   |
 | --------------------------------------- | ---------------------------------------------------------------------------- |
 | **並列開発** 新機能とバグ修正を同時進行 | `mst create feature/auth --tmux --claude`<br>`mst create bugfix/login-issue` |
-| **状態確認** 演奏者一覧を表示           | `mst list --details`                                                         |
+| **状態確認** 演奏者一覧を表示           | `mst list`                                                                   |
 | **高速切替** tmux セッションへ          | `mst tmux`                                                                   |
 | **GitHub Issue から作成**               | `mst create 123`                                                             |
-| **GitHub PR から作成**                  | `mst github pr 456`                                                          |
+| **GitHub PR から作成**                  | `mst github checkout 456`                                                    |
 | **ドラフト PR を自動作成**              | `mst create feature/new-ui --draft-pr`                                       |
 | **AI レビュー** 差分レビューを生成      | `mst suggest --review`                                                       |
 | **自動レビュー & マージ**               | `mst review --auto-flow`                                                     |
@@ -120,15 +120,15 @@ mst create feature/awesome-feature --tmux --claude
 | コマンド    | 説明                       | ショート例                     |
 | ----------- | -------------------------- | ------------------------------ |
 | `create`    | 新しい worktree を作成     | `mst create feature/login`     |
-| `list`      | worktree を一覧表示        | `mst list --details`           |
+| `list`      | worktree を一覧表示        | `mst list`                     |
 | `delete`    | worktree を削除            | `mst delete feature/old --fzf` |
 | `tmux`      | tmux セッションで開く      | `mst tmux`                     |
 | `sync`      | ファイルをリアルタイム同期 | `mst sync --auto`              |
 | `suggest`   | Claude 提案/レビュー       | `mst suggest --review`         |
-| `github`    | Issue / PR 連携            | `mst github pr 123`            |
+| `github`    | Issue / PR 連携            | `mst github checkout 123`      |
 | `dashboard` | Web ダッシュボード起動     | `mst dashboard --open`         |
 | `health`    | worktree 健全性チェック    | `mst health --fix`             |
-| `where`     | 現在位置確認               | `mst where --verbose`          |
+| `where`     | 現在位置確認               | `mst where`                    |
 
 すべてのサブコマンドと詳細オプションは [コマンドリファレンス](./docs/COMMANDS.md) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ mst create feature/awesome-feature --tmux --claude
 | Goal                              | Command Example                                                              |
 | --------------------------------- | ---------------------------------------------------------------------------- |
 | **Parallel dev** Feature + bugfix | `mst create feature/auth --tmux --claude`<br>`mst create bugfix/login-issue` |
-| **List performers**               | `mst list --details`                                                         |
+| **List performers**               | `mst list`                                                                   |
 | **Fast switch** via tmux          | `mst tmux`                                                                   |
 | **Create from GitHub Issue**      | `mst create 123`                                                             |
-| **Create from PR**                | `mst github pr 456`                                                          |
+| **Create from PR**                | `mst github checkout 456`                                                    |
 | **Auto draft PR**                 | `mst create feature/new-ui --draft-pr`                                       |
 | **AI diff review**                | `mst suggest --review`                                                       |
 | **Auto review & merge**           | `mst review --auto-flow`                                                     |
@@ -119,18 +119,18 @@ See the full [Command Reference](./docs/COMMANDS.md).
 
 ### Main Commands
 
-| Command     | Description                  | Example                        |
-| ----------- | ---------------------------- | ------------------------------ |
-| `create`    | Create a new worktree        | `mst create feature/login`     |
-| `list`      | List worktrees               | `mst list --details`           |
-| `delete`    | Delete worktree              | `mst delete feature/old --fzf` |
-| `tmux`      | Open in tmux                 | `mst tmux`                     |
-| `sync`      | Real-time file sync          | `mst sync --auto`              |
-| `suggest`   | Claude suggestions / reviews | `mst suggest --review`         |
-| `github`    | GitHub integration           | `mst github pr 123`            |
-| `dashboard` | Launch Web dashboard         | `mst dashboard --open`         |
-| `health`    | Health check                 | `mst health --fix`             |
-| `where`     | Show current performer       | `mst where --verbose`          |
+| Command     | Description                  | Example                         |
+| ----------- | ---------------------------- | ------------------------------- |
+| `create`    | Create a new worktree        | `mst create feature/login`      |
+| `list`      | List worktrees               | `mst list`                      |
+| `delete`    | Delete worktree              | `mst delete feature/old --fzf`  |
+| `tmux`      | Open in tmux                 | `mst tmux`                      |
+| `sync`      | Real-time file sync          | `mst sync --auto`               |
+| `suggest`   | Claude suggestions / reviews | `mst suggest --review`          |
+| `github`    | GitHub integration           | `mst github checkout 123`       |
+| `dashboard` | Launch Web dashboard         | `mst dashboard --open`          |
+| `health`    | Health check                 | `mst health --fix`              |
+| `where`     | Show current performer       | `mst where`                     |
 
 All sub-commands and options are documented in the [Command Reference](./docs/COMMANDS.md).
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -61,6 +61,7 @@ mst list [options]
 - `--metadata` - Show metadata info
 - `--full-path` - Show full paths instead of relative paths
 - `--fzf` - Select with fzf (outputs selected branch name)
+- `--names` - Machine-readable output (for scripting)
 
 #### Examples
 ```bash
@@ -75,6 +76,11 @@ mst list --sort size
 
 # Show full paths
 mst list --full-path
+
+# For scripting
+for worktree in $(mst list --names); do
+  echo "Processing $worktree"
+done
 ```
 
 ### 🗑️ delete - Delete Orchestra Member
@@ -150,6 +156,8 @@ mst sh [branch-name] [options]  # alias
 - `--fzf` - Select with fzf
 - `--cmd <command>` - Execute command and exit
 - `--tmux` - Attach to tmux session (create if doesn't exist)
+- `--tmux-vertical`, `--tmux-v` - Open shell in vertical split pane
+- `--tmux-horizontal`, `--tmux-h` - Open shell in horizontal split pane
 
 #### Examples
 ```bash
@@ -161,6 +169,12 @@ mst shell --fzf
 
 # Execute command
 mst shell feature/test --cmd "npm test"
+
+# Open in vertical split pane
+mst shell feature/new --tmux-v
+
+# Open in horizontal split pane
+mst shell feature/test --tmux-h
 ```
 
 ## Integration Commands
@@ -199,31 +213,41 @@ mst suggest --pr --description "Implement login feature"
 Provides GitHub integration features.
 
 ```bash
-mst github [options]
+mst github [type] [number] [options]
+mst gh [type] [number] [options]  # alias
 ```
 
+#### Arguments
+- `type` - Type (checkout, pr, issue, comment)
+- `number` - PR/Issue number
+
 #### Options
-- `--issue <number>` - Create orchestra member from issue
-- `--pr <number>` - Create orchestra member from PR
-- `--create-pr` - Create PR
-- `--draft` - Create as Draft PR
-- `--branch <name>` - Specify branch name
 - `-o, --open` - Open in editor
 - `-s, --setup` - Execute environment setup
 - `-m, --message <message>` - Comment message
 - `--reopen` - Reopen PR/Issue
 - `--close` - Close PR/Issue
+- `-t, --tmux` - Open in new tmux window
+- `--tmux-vertical`, `--tmux-v` - Open in vertical split pane
+- `--tmux-horizontal`, `--tmux-h` - Open in horizontal split pane
 
 #### Examples
 ```bash
-# Create from Issue #123
-mst github --issue 123
+# Create from PR #123
+mst github checkout 123
+mst gh 123  # shorthand
 
-# Create from PR #456
-mst github --pr 456
+# Create from Issue #456
+mst github issue 456
 
-# Create PR from current branch
-mst github --create-pr
+# Create and open in tmux
+mst github 123 --tmux
+
+# Create and open in vertical split
+mst github 123 --tmux-v
+
+# Add comment to PR/Issue
+mst github comment 123 -m "LGTM!"
 ```
 
 ### 🖥️ tmux - tmux Integration
@@ -414,26 +438,37 @@ mst where --verbose
 
 ### 🔗 exec - Execute Commands
 
-Execute same command in all orchestra members.
+Execute command in a specific orchestra member or all orchestra members.
 
 ```bash
-mst exec <command> [options]
+mst exec [branch-name] <command> [options]
+mst e [branch-name] <command> [options]  # alias
 ```
 
 #### Options
-- `--parallel` - Execute in parallel
-- `--continue-on-error` - Continue on error
-- `--dry-run` - Preview only
 - `-s, --silent` - Suppress output
 - `-a, --all` - Execute on all orchestra members
+- `--fzf` - Select orchestra member with fzf
+- `-t, --tmux` - Execute in new tmux window
+- `--tmux-vertical`, `--tmux-v` - Execute in vertical split pane
+- `--tmux-horizontal`, `--tmux-h` - Execute in horizontal split pane
 
 #### Examples
 ```bash
-# Run tests in all
-mst exec "npm test"
+# Execute in specific orchestra member
+mst exec feature/test npm test
 
-# Parallel execution
-mst exec "npm run lint" --parallel
+# Execute in all orchestra members
+mst exec --all npm run lint
+
+# Select with fzf
+mst exec --fzf npm run dev
+
+# Execute in tmux
+mst exec feature/api --tmux npm run watch
+
+# Execute in vertical split
+mst exec --fzf --tmux-v npm test
 ```
 
 ### 🔄 batch - Batch Processing

--- a/docs/commands/exec.md
+++ b/docs/commands/exec.md
@@ -1,0 +1,150 @@
+# 🔗 exec - Execute Commands
+
+Execute commands in specific or all orchestra members.
+
+## Overview
+
+The `exec` command allows you to run any command within the context of one or multiple worktrees without entering their shell environment. This is particularly useful for running build commands, tests, or any other operations across your orchestra members.
+
+## Usage
+
+```bash
+mst exec [branch-name] <command> [options]
+mst e [branch-name] <command> [options]  # alias
+```
+
+## Options
+
+- `-s, --silent` - Suppress command output
+- `-a, --all` - Execute on all orchestra members
+- `--fzf` - Interactively select orchestra member with fzf
+- `-t, --tmux` - Execute in new tmux window
+- `--tmux-vertical`, `--tmux-v` - Execute in vertical split pane
+- `--tmux-horizontal`, `--tmux-h` - Execute in horizontal split pane
+
+## Examples
+
+### Basic Usage
+
+Execute a command in a specific orchestra member:
+
+```bash
+# Run tests in feature branch
+mst exec feature/awesome npm test
+
+# Build project
+mst exec feature/ui npm run build
+
+# Check git status
+mst exec hotfix/urgent git status
+```
+
+### Execute in All Orchestra Members
+
+Run the same command across all worktrees:
+
+```bash
+# Install dependencies in all
+mst exec --all npm install
+
+# Run linting in all
+mst exec --all npm run lint
+
+# Check git status of all
+mst exec --all git status --short
+```
+
+### Interactive Selection with fzf
+
+Select which orchestra member to execute in:
+
+```bash
+# Select and run dev server
+mst exec --fzf npm run dev
+
+# Select and run tests
+mst exec --fzf npm test
+```
+
+### tmux Integration
+
+Execute commands in tmux panes for better workflow:
+
+```bash
+# Open in new tmux window
+mst exec feature/api --tmux npm run watch
+
+# Open in vertical split (side by side)
+mst exec feature/ui --tmux-v npm run dev
+
+# Open in horizontal split (top and bottom)
+mst exec backend --tmux-h npm run test:watch
+
+# Combine with fzf selection
+mst exec --fzf --tmux npm start
+```
+
+## Environment Variables
+
+When executing commands, these environment variables are automatically set:
+
+- `MAESTRO_BRANCH` - The branch name of the worktree
+- `MAESTRO_PATH` - The absolute path to the worktree
+
+## Use Cases
+
+1. **Running Tests**
+   ```bash
+   # Run tests in specific branch
+   mst exec feature/auth npm test
+   
+   # Run tests in all branches
+   mst exec --all npm test
+   ```
+
+2. **Building Projects**
+   ```bash
+   # Build specific feature
+   mst exec feature/ui npm run build
+   
+   # Build all features
+   mst exec --all npm run build
+   ```
+
+3. **Git Operations**
+   ```bash
+   # Check status
+   mst exec feature/api git status
+   
+   # Pull latest changes in all
+   mst exec --all git pull
+   ```
+
+4. **Development Servers**
+   ```bash
+   # Start dev server with tmux
+   mst exec feature/frontend --tmux npm run dev
+   
+   # Start multiple servers in splits
+   mst exec backend --tmux-v npm run server
+   mst exec frontend --tmux-h npm run dev
+   ```
+
+## Tips
+
+- Use `--silent` to suppress output when running in multiple worktrees
+- Combine `--fzf` with tmux options for interactive workflow
+- Use quotes for complex commands: `mst exec feature "npm run build && npm test"`
+- The command is executed with `sh -c`, so shell features like pipes and redirects work
+
+## Error Handling
+
+- If the specified branch doesn't exist, suggestions for similar branches are shown
+- Exit codes from executed commands are preserved
+- Use `--all` carefully as it executes in all worktrees sequentially
+
+## Related Commands
+
+- [shell](./shell.md) - Enter an interactive shell
+- [batch](./batch.md) - Batch operations on multiple worktrees
+- [list](./list.md) - List all orchestra members

--- a/docs/commands/github.md
+++ b/docs/commands/github.md
@@ -5,8 +5,8 @@ Command to create orchestra members (Git Worktrees) directly from GitHub Issues 
 ## Overview
 
 ```bash
-mst github [pr|issue] [number] [options]
-mst gh [pr|issue] [number] [options]  # alias
+mst github [type] [number] [options]
+mst gh [type] [number] [options]  # alias
 ```
 
 ## Usage Examples
@@ -15,41 +15,47 @@ mst gh [pr|issue] [number] [options]  # alias
 
 ```bash
 # Create orchestra member from Pull Request
-mst github pr 123
+mst github checkout 123
+mst gh 123  # shorthand
 
 # Create orchestra member from Issue
 mst github issue 456
 
 # Interactive selection
 mst github
+
+# Add comment to PR/Issue
+mst github comment 123 -m "LGTM!"
 ```
 
 ### Advanced Usage
 
 ```bash
-# Create PR and auto-start Claude Code
-mst github pr 123 --tmux --claude
+# Create and open in tmux
+mst github 123 --tmux
 
-# Multiple selection for batch creation
-mst github --multiple
+# Create and open in vertical split
+mst github 123 --tmux-v
 
-# Filter and select
-mst github issue --filter "label:bug"
+# Create and open in horizontal split
+mst github 123 --tmux-h
 
-# Show only assigned to me
-mst github --assignee @me
+# Create with automatic setup
+mst github 123 --open --setup
 ```
 
 ## Options
 
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
-| `--tmux` | `-t` | Create tmux session/window | `false` |
-| `--claude` | `-c` | Auto-start Claude Code | `false` |
-| `--multiple` | `-m` | Multiple selection mode | `false` |
-| `--filter <query>` | `-f` | GitHub CLI filter query | none |
-| `--assignee <user>` | `-a` | Filter by assignee (@me for self) | none |
-| `--limit <n>` | `-l` | Limit number of displayed items | `30` |
+| `--open` | `-o` | Open in editor after creation | `false` |
+| `--setup` | `-s` | Execute environment setup | `false` |
+| `--message <message>` | `-m` | Comment message (for comment subcommand) | none |
+| `--reopen` | | Reopen PR/Issue | `false` |
+| `--close` | | Close PR/Issue | `false` |
+| `--tmux` | `-t` | Open in new tmux window | `false` |
+| `--tmux-vertical` | `--tmux-v` | Open in vertical split pane | `false` |
+| `--tmux-horizontal` | `--tmux-h` | Open in horizontal split pane | `false` |
 
 ## Creating from Pull Requests
 

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -41,6 +41,7 @@ mst list --full-path
 | `--sort`       |        | Sort by field (branch, age, size)      | `branch` |
 | `--last-commit`|        | Show last commit information           | `false`  |
 | `--full-path`  |        | Show full paths instead of relative    | `false`  |
+| `--names`      |        | Machine-readable output (for scripting)| `false`  |
 
 ## Output Formats
 
@@ -158,6 +159,25 @@ By default, paths are shown relative to the repository root:
 
 🎼 feature/auth                   .git/orchestrations/feature-auth
     Last commit: 2025-01-19 10:15:30 def5678: Add login endpoint
+```
+
+### Names Output (`--names`)
+
+Machine-readable output that prints only branch names, one per line. Perfect for scripting:
+
+```bash
+# Simple output
+$ mst list --names
+main
+feature/auth
+bugfix/login
+issue-123
+
+# Use in scripts
+for branch in $(mst list --names); do
+  echo "Processing $branch..."
+  mst exec "$branch" git status --short
+done
 ```
 
 ## fzf Integration

--- a/docs/commands/shell.md
+++ b/docs/commands/shell.md
@@ -1,0 +1,168 @@
+# 🐚 shell - Enter Orchestra Member Shell
+
+Enter an interactive shell session in an orchestra member.
+
+## Overview
+
+The `shell` command provides an interactive shell environment within a specific worktree. This allows you to work directly in the context of a feature branch with all environment variables properly set.
+
+## Usage
+
+```bash
+mst shell [branch-name] [options]
+mst sh [branch-name] [options]  # alias
+```
+
+## Options
+
+- `--fzf` - Interactively select orchestra member with fzf
+- `--cmd <command>` - Execute command and exit (non-interactive)
+- `--tmux` - Attach to existing tmux session (create if doesn't exist)
+- `--tmux-vertical`, `--tmux-v` - Open shell in vertical split pane
+- `--tmux-horizontal`, `--tmux-h` - Open shell in horizontal split pane
+
+## Examples
+
+### Basic Usage
+
+Enter a shell in a specific orchestra member:
+
+```bash
+# Enter shell
+mst shell feature/awesome
+
+# Using alias
+mst sh feature/api
+```
+
+### Interactive Selection
+
+Use fzf to select which orchestra member to enter:
+
+```bash
+# Select with fzf
+mst shell --fzf
+
+# Shorthand without branch name
+mst sh --fzf
+```
+
+### Execute Command and Exit
+
+Run a single command without entering interactive shell:
+
+```bash
+# Run tests and exit
+mst shell feature/test --cmd "npm test"
+
+# Check Node version
+mst shell backend --cmd "node --version"
+```
+
+### tmux Integration
+
+Work with tmux for better session management:
+
+```bash
+# Attach to existing tmux session or create new
+mst shell feature/ui --tmux
+
+# Open in vertical split (side by side)
+mst shell feature/api --tmux-v
+
+# Open in horizontal split (top and bottom)
+mst shell feature/db --tmux-h
+
+# Combine with fzf
+mst shell --fzf --tmux-v
+```
+
+## Environment Variables
+
+When in a maestro shell, these environment variables are automatically set:
+
+- `MAESTRO` - Set to "1" (indicates you're in a maestro shell)
+- `MAESTRO_BRANCH` - The branch name of current worktree
+- `MAESTRO_PATH` - The absolute path to the worktree
+
+## Shell Customization
+
+The shell prompt is automatically customized to show the current orchestra member:
+
+- **Bash**: `🎼 [branch-name] ~/path $ `
+- **Zsh**: `🎼 [branch-name] ~/path $ `
+- **Fish**: `🎼 [branch-name] ~/path $ `
+
+The shell type is determined by your `$SHELL` environment variable.
+
+## tmux Features
+
+### Session Management
+
+When using `--tmux`:
+- Creates a session named `maestro-{branch-name}`
+- Reattaches to existing session if available
+- Maintains separate session per orchestra member
+
+### Pane Splitting
+
+When using `--tmux-v` or `--tmux-h`:
+- Creates a new pane in current tmux window
+- Sets pane title to branch name
+- Automatically configures tmux status line
+
+## Use Cases
+
+1. **Development Work**
+   ```bash
+   # Enter frontend development environment
+   mst shell feature/ui
+   
+   # Start with tmux for long sessions
+   mst shell feature/backend --tmux
+   ```
+
+2. **Quick Commands**
+   ```bash
+   # Run migrations
+   mst shell main --cmd "npm run migrate"
+   
+   # Check dependencies
+   mst shell feature/auth --cmd "npm ls"
+   ```
+
+3. **Multiple Environments**
+   ```bash
+   # Open frontend and backend in splits
+   mst shell frontend --tmux-v
+   mst shell backend --tmux-v
+   ```
+
+4. **Interactive Workflow**
+   ```bash
+   # Select and enter with fzf
+   mst shell --fzf
+   
+   # Select and open in tmux
+   mst shell --fzf --tmux
+   ```
+
+## Tips
+
+- Use `--tmux` for long-running development sessions
+- Use `--cmd` for quick one-off commands
+- Combine `--fzf` with tmux options for flexible workflow
+- Exit the shell with `exit` or Ctrl+D
+- Your shell history is maintained per orchestra member
+
+## Notes
+
+- tmux options require being inside an existing tmux session
+- The shell inherits your normal shell configuration (.bashrc, .zshrc, etc.)
+- Use `mst where` inside a shell to confirm current location
+
+## Related Commands
+
+- [exec](./exec.md) - Execute commands without entering shell
+- [create](./create.md) - Create new orchestra members
+- [list](./list.md) - List all orchestra members


### PR DESCRIPTION
## Summary
Fixed incorrect command examples in README.md and README.ja.md to match actual implementation.

## Changes
- `mst list --details` → `mst list` (--details option doesn't exist)
- `mst github pr 456` → `mst github checkout 456` (updated to new syntax)
- `mst where --verbose` → `mst where` (show basic usage)

## Related
- Follows up on PR #41 documentation updates
- Ensures README examples match v2.4.0 implementation

🤖 Generated with [Claude Code](https://claude.ai/code)